### PR TITLE
Allow user to set a custom logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
 exports.Pathfinder = require('./lib/pathfinder').Pathfinder
+exports.setLogger = require('./lib/log').setLogger

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const log = require('@ripple/five-bells-shared/services/log')('broker')
+const log = require('./log')('broker')
 
 function Broker () {
   this.broadcaster = null

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
 const request = require('co-request')
 const emitter = require('co-emitter')
 const each = require('co-foreach')
-const log = require('@ripple/five-bells-shared/services/log')('crawler')
+const log = require('./log')('crawler')
 
 exports.Crawler = Crawler
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = (component) => makeLogger(component)
+
+// Default logger is the console
+let makeLogger = (component) => console
+module.exports.setLogger = function (logFactory) {
+  makeLogger = logFactory
+}

--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const log = require('@ripple/five-bells-shared/services/log')('orchestrator')
+const log = require('./log')('orchestrator')
 
 const request = require('co-request')
 const uuid = require('uuid4')

--- a/lib/pathfinder.js
+++ b/lib/pathfinder.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const log = require('@ripple/five-bells-shared/services/log')('pathfinder')
+const log = require('./log')('pathfinder')
 const Graph = require('./dijkstra').Graph
 const Crawler = require('./crawler').Crawler
 const Broker = require('./broker').Broker

--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const request = require('co-request')
-const log = require('@ripple/five-bells-shared/services/log')('subscriber')
+const log = require('./log')('subscriber')
 
 function Subscriber (config, crawler) {
   this.crawler = crawler

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "co-foreach": "^1.0.6",
     "co-request": "^0.2.0",
     "co-stream": "^0.1.0",
-    "@ripple/five-bells-shared": "2.6.3",
     "lodash": "^3.5.0",
     "mag": "^0.9.1",
     "mag-hub": "^0.1.1",


### PR DESCRIPTION
Since pathfind is just a module (not a whole application) it should not instantiate any services. Services generally can malfunction if multiple instances are created in the same process.

In the current version of `five-bells-demo`, this causes a crash because multiple instances of the log service in five-bells-shared are trying to be instantiated. (Issue will not appear when using `npm link`.)

By making the logging pluggable, this module also no longer requires five-bells-shared.
