### PR TITLE
[FEATURE + FIX] Use /connectors, not /accounts 

### DIFF
--- a/src/crawler.js
+++ b/src/crawler.js
@@ -85,7 +85,7 @@ class Crawler extends emitter {
       }
 
       // For pathfinding we want to see all directed edges
-      yield this.emit('pair', {
+      this.emit('pair', {
         source: pair.source_ledger,
         destination: pair.destination_ledger,
         uri: node.uri

--- a/src/crawler.js
+++ b/src/crawler.js
@@ -47,7 +47,7 @@ class Crawler extends emitter {
     this.ledgers[node.uri] = node
     yield this.emit('ledger', {id: node.uri})
     let res = yield request
-      .get(node.uri + '/accounts')
+      .get(node.uri + '/connectors')
     if (res.status === 200) {
       for (let person of res.body) {
         // Currently only traders have the `identity` property set

--- a/src/crawler.js
+++ b/src/crawler.js
@@ -50,11 +50,11 @@ class Crawler extends emitter {
       .get(node.uri + '/connectors')
     if (res.status === 200) {
       for (let person of res.body) {
-        // Currently only traders have the `identity` property set
-        if (person.identity) {
-          if (!this.visitedNodes[person.identity]) {
-            this.visitedNodes[person.identity] = true
-            this.queueNode('trader', person.identity)
+        // Currently only traders have the `connector` property set
+        if (person.connector) {
+          if (!this.visitedNodes[person.connector]) {
+            this.visitedNodes[person.connector] = true
+            this.queueNode('trader', person.connector)
           }
         } else {
           const nodeId = person.id

--- a/src/pathfinder.js
+++ b/src/pathfinder.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _ = require('lodash')
+const co = require('co')
 const BigNumber = require('bignumber.js')
 const log = require('./log')('pathfinder')
 const Graph = require('./graph').Graph
@@ -18,7 +19,7 @@ class Pathfinder {
     this.graph = {}
     this.quotingClient = new QuotingClient(this.crawler)
 
-    this.crawler.on('pair', function *(pair) {
+    this.crawler.on('pair', function (pair) {
       _this.handleNewEdge(pair)
     })
   }
@@ -31,8 +32,8 @@ class Pathfinder {
     return this.crawler.getLedgers()
   }
 
-  * crawl () {
-    yield this.crawler.crawl()
+  crawl () {
+    return co(this.crawler.crawl.bind(this.crawler))
   }
 
   handleNewEdge (pair) {
@@ -55,7 +56,7 @@ class Pathfinder {
     return cheapestPath
   }
 
-  * findPath (sourceLedger, destinationLedger, destinationAmount) {
+  * _findPath (sourceLedger, destinationLedger, destinationAmount) {
     log.info('findPath ' + sourceLedger + ' -> ' + destinationLedger)
 
     const graph = new Graph({
@@ -78,6 +79,10 @@ class Pathfinder {
     log.info('got cheapest path: ' + JSON.stringify(cheapestPath))
 
     return cheapestPath
+  }
+
+  findPath (sourceLedger, destinationLedger, destinationAmount) {
+    return co(this._findPath.bind(this), sourceLedger, destinationLedger, destinationAmount)
   }
 }
 

--- a/src/quoting-client.js
+++ b/src/quoting-client.js
@@ -10,7 +10,7 @@ class QuotingClient {
     this.crawler = crawler
     this.pairs = {}
 
-    this.crawler.on('pair', function * (pair) {
+    this.crawler.on('pair', function (pair) {
       _this.handleTradingPair(pair)
     })
   }


### PR DESCRIPTION
* `/accounts` requires admin credentials, `/connectors` requires none.
* Depends on https://github.com/interledger/five-bells-ledger/pull/84
* Wraps public functions in `co()` rather than exposing generators. This is an API change, so we will have to bump the version.